### PR TITLE
Use positional read adapter to avoid mandatory mem-mapping

### DIFF
--- a/src/barc.rs
+++ b/src/barc.rs
@@ -213,7 +213,7 @@ struct RecordHead {
 /// Additonal getter methods are found in trait implementations
 /// [`RequestRecorded`](#impl-RequestRecorded), [`Recorded`](#impl-Recorded),
 /// and [`MetaRecorded`](#impl-MetaRecorded).
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Record {
     /// Record type.
     pub rec_type:         RecordType,

--- a/src/client.rs
+++ b/src/client.rs
@@ -489,7 +489,7 @@ mod tests {
         let req = create_request("https://www.usa.gov").unwrap();
 
         let dl = fetch(req, &tune).unwrap();
-        let dl = dl.try_clone().unwrap();
+        let dl = dl.clone();
         println!("Response {:#?}", dl);
 
         assert!(dl.res_body.is_ram());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -646,8 +646,9 @@ pub enum BodyReader<'a> {
     /// buffers.
     Scattered(GatheringReader<'a>),
 
-    /// `ReadPos` providing instance independent `Read` and `Seek` for
-    /// BodyImage `FsRead` state.
+    /// `ReadPos` providing instance independent, unbuffered `Read` and `Seek`
+    /// for BodyImage `FsRead` state. Consider wrapping this in
+    /// `std::io::BufReader` if performing many small reads.
     File(ReadPos),
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,8 @@
                            pub mod barc;
 #[cfg(feature = "client")] pub mod client;
 
+mod read_pos;
+
 use std::env;
 use std::fmt;
 use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,16 +401,16 @@ impl BodyImage {
         self.len
     }
 
-    /// Prepare for re-reading. This is no longer necessary and is currently a
-    /// No-op. The `reader` method always returns a `Read` from the start of
-    /// the `BodyImage` for all states.
+    /// Formerly, this rewound 'FsRead', but now is an unnecessary no-op. The
+    /// `reader` method always returns a `Read` from the start of the
+    /// `BodyImage` for all states.
     #[deprecated]
     pub fn prepare(&mut self) -> Result<&mut Self, BodyError> {
         Ok(self)
     }
 
-    /// If `FsRead`, convert to `MemMap` by memory mapping the file. No-op
-    /// for other states.
+    /// If `FsRead`, convert to `MemMap` by memory mapping the file. No-op for
+    /// other states.
     pub fn mem_map(&mut self) -> Result<&mut Self, BodyError> {
         if let ImageState::FsRead(_) = self.state {
             assert!(self.len > 0);
@@ -458,9 +458,8 @@ impl BodyImage {
         self
     }
 
-    /// Attempt to clone self by shallow copy, returning a new
-    /// `BodyImage`. This is currently infallible and deprecated in favor of
-    /// `clone`.
+    /// Clone self by shallow copy, returning a new `BodyImage`. This is
+    /// currently infallible and deprecated in favor of `clone`.
     #[deprecated]
     pub fn try_clone(&self) -> Result<BodyImage, BodyError> {
         Ok(self.clone())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,8 +647,9 @@ pub enum BodyReader<'a> {
     /// buffers.
     Scattered(GatheringReader<'a>),
 
-    /// `ReadPos` independent `Read` and `Seek` for BodyImage `FsRead` state.
-    File(ReadPos<File>),
+    /// `ReadPos` providing instance independent `Read` and `Seek` for
+    /// BodyImage `FsRead` state.
+    File(ReadPos),
 }
 
 impl<'a> BodyReader<'a> {

--- a/src/read_pos.rs
+++ b/src/read_pos.rs
@@ -11,7 +11,7 @@ use std::os::unix::fs::FileExt;
 #[cfg(windows)]
 use std::os::windows::fs::FileExt;
 
-/// Re-implements `Seek` and `Read` over a `File` reference using only
+/// Re-implements `Read` and `Seek` over a shared `File` reference using only
 /// `FileExt` (platform specific) `read_at`/`seek_read`, and by maintaining an
 /// instance independent position.
 ///
@@ -201,5 +201,4 @@ mod tests {
         assert!(is_send::<ReadPos>());
         assert!(is_sync::<ReadPos>());
     }
-
 }

--- a/src/read_pos.rs
+++ b/src/read_pos.rs
@@ -1,0 +1,209 @@
+//! Experimental
+
+use std::io;
+use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+use std::sync::Arc;
+
+#[cfg(unix)]
+use std::os::unix::fs::FileExt;
+
+#[cfg(windows)]
+use std::os::windows::fs::FileExt;
+
+/// Implements `Seek` and `Read` for a `FileExt` reference (platform specific
+/// `read_at`/`seek_read` for `File`) by maintaining an instance specific
+/// position. This effectively enables independent offsets for a single `File`
+/// handle.
+#[derive(Debug)]
+pub struct ReadPos<T: FileExt + Sync + Send>
+{
+    pos: u64,
+    size: u64,
+    file: Arc<T>,
+}
+
+// Manual implementation of clone required, apparently due to:
+// https://github.com/rust-lang/rust/issues/26925
+impl<T: FileExt + Sync + Send> Clone for ReadPos<T> {
+    /// Return a new instance of self with position 0 (throws away
+    /// any original position).
+    fn clone(&self) -> ReadPos<T> {
+        ReadPos { pos: 0, size: self.size, file: self.file.clone() }
+    }
+}
+
+impl<T: FileExt + Sync + Send> ReadPos<T>
+{
+    fn new(file: T, size: u64) -> ReadPos<T> {
+        ReadPos { pos: 0, size, file: Arc::new(file) }
+    }
+
+    /// Consume self and return the original T, or if there are more than one
+    /// strong reference oustanding (via clone), return self.
+    fn try_unwrap(self) -> Result<T, Self> {
+        match Arc::try_unwrap(self.file) {
+            Ok(t) => Ok(t),
+            Err(arc_t) => Err(ReadPos {
+                pos: self.pos,
+                size: self.size,
+                file: arc_t
+            })
+        }
+    }
+
+    #[cfg_attr(feature = "cargo-clippy", allow(collapsible_if))]
+    fn seek_from(&mut self, origin: u64, offset: i64) -> io::Result<u64> {
+        if offset < 0 {
+            if let Some(p) = origin.checked_sub((-offset) as u64) {
+                self.pos = p;
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Invalid attempt to seek to a negative absolute position"
+                ));
+            }
+        } else {
+            if let Some(p) = origin.checked_add(offset as u64) {
+                self.pos = p;
+            } else {
+                return Err(Error::new(
+                    ErrorKind::Other,
+                    "Attempted seek would overflow u64 position"
+                ));
+            }
+        }
+        Ok(self.pos)
+    }
+}
+
+impl<T: FileExt + Sync + Send> Read for ReadPos<T>
+{
+    #[cfg(unix)]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = self.file.read_at(buf, self.pos)?;
+        self.pos += len as u64;
+        Ok(len)
+    }
+
+    #[cfg(windows)]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let len = self.file.seek_read(buf, self.pos)?;
+        self.pos += len as u64;
+        Ok(len)
+    }
+}
+
+impl<T: FileExt + Sync + Send> Seek for ReadPos<T>
+{
+    fn seek(&mut self, from: SeekFrom) -> io::Result<u64> {
+        match from {
+            SeekFrom::Start(p) => {
+                self.pos = p;
+                Ok(p)
+            }
+            SeekFrom::End(offset) => {
+                let origin = self.size;
+                self.seek_from(origin, offset)
+            }
+            SeekFrom::Current(offset) => {
+                let origin = self.pos;
+                self.seek_from(origin, offset)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::{Read, Write};
+    use std::thread;
+    use ::tempfile::tempfile;
+    use super::*;
+
+    #[test]
+    fn test_seek() {
+        let mut f = tempfile().unwrap();
+        f.write_all(b"1234567890").unwrap();
+
+        let mut r1 = ReadPos::new(f, 10);
+        let mut buf = [0u8; 5];
+
+        let p = r1.seek(SeekFrom::Current(0)).unwrap();
+        assert_eq!(0, p);
+        let p = r1.seek(SeekFrom::Current(1)).unwrap();
+        assert_eq!(1, p);
+        r1.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"23456");
+
+        let p = r1.seek(SeekFrom::End(-5)).unwrap();
+        assert_eq!(5, p);
+        let p = r1.seek(SeekFrom::Current(0)).unwrap();
+        assert_eq!(5, p);
+        r1.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"67890");
+    }
+
+    #[test]
+    fn test_interleaved() {
+        let mut f = tempfile().unwrap();
+        f.write_all(b"1234567890").unwrap();
+
+        let mut r1 = ReadPos::new(f, 10);
+
+        {
+            let mut buf = [0u8; 5];
+            r1.read_exact(&mut buf).unwrap();
+            assert_eq!(&buf, b"12345");
+
+            let mut r2 = r1.clone();
+            r2.read_exact(&mut buf).unwrap();
+            assert_eq!(&buf, b"12345");
+
+            r1.read_exact(&mut buf).unwrap();
+            assert_eq!(&buf, b"67890");
+
+            r2.read_exact(&mut buf).unwrap();
+            assert_eq!(&buf, b"67890");
+        }
+
+        assert!(r1.try_unwrap().is_ok())
+    }
+
+    #[test]
+    fn test_concurrent_seek_read() {
+        let mut f = tempfile().unwrap();
+        let rule = b"1234567890";
+        f.write_all(rule).unwrap();
+        let rp = ReadPos::new(f, rule.len() as u64);
+
+        let mut threads = Vec::with_capacity(30);
+        for i in 0..50 {
+            let mut rpc = rp.clone();
+            threads.push(thread::spawn( move || {
+                let p = i % rule.len();
+                rpc.seek(SeekFrom::Start(p as u64)).expect("seek");
+
+                thread::yield_now();
+
+                let l = 5.min(rule.len() - p);
+                let mut buf = vec![0u8; l];
+                rpc.read_exact(&mut buf).expect("read_exact");
+                assert_eq!(&buf[..], &rule[p..(p+l)]);
+            }))
+        }
+        for t in threads {
+            t.join().unwrap();
+        }
+    }
+
+    fn is_send<T: Send>() -> bool { true }
+    fn is_sync<T: Sync>() -> bool { true }
+
+    #[test]
+    fn test_send_sync() {
+        assert!(is_send::<ReadPos<File>>());
+        assert!(is_sync::<ReadPos<File>>());
+    }
+
+}


### PR DESCRIPTION
The unlinked tempfile has great properties but doesn't support independent positioned file handles (dup'd file handles are not independent).

Previously: 
* `BodyImage` (and Dialog) `try_clone` was introduced with mandatory mem-mapping to avoid exposing non-independent read access to `FsRead`, which could be very surprising.
* `BodyImage::write_to` created a temporary mem-map to avoid mutating `FsRead`.

Now:
* New `ReadPos` wrapper re-implements `Seek` and `Read` over a `File` reference using only `FileExt` (platform specific) `read_at`/`seek_read`, and by maintaining an instance independent position.
* `FsRead` state now uses `Arc<File>`
* `BodyImage::reader` uses `ReadPos` for `FsRead` state.
* `BodyImage`, `Dialog` and `Record` all implement infallible `clone`
* `try_clone` methods are deprecated
* `BodyImage::prepare` is now no-op, deprecated